### PR TITLE
Changed minimum deployment target to iOS 12.0 (was 13.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Wave",
     platforms: [
-       .iOS(.v13)
+       .iOS(.v12)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
Wave currently does not appear to require iOS 13 APIs. I integrated this change in an app with a minimum deployment target of iOS 12 and tested it on an iPhone 5s running iOS 12.5.5, using both the block-based and the property-based API, and found no issue.

Allowing iOS 12 instead of 13 means that client apps don't need to make the following models prematurely obsolete: iPhone 5s, iPod touch 6th generation, iPad mini 2, iPad mini 3, iPad Air, 9.7-inch iPad 6th generation.

