### PR TITLE
Support high frame rate animations on ProMotion devices

### DIFF
--- a/Sample App/Wave-Sample/Wave-Sample/Info.plist
+++ b/Sample App/Wave-Sample/Wave-Sample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDuration</key>
+	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Sources/Wave/AnimationController.swift
+++ b/Sources/Wave/AnimationController.swift
@@ -77,7 +77,20 @@ internal class AnimationController {
     private func startDisplayLink() {
         if displayLink == nil {
             displayLink = CADisplayLink(target: self, selector: #selector(updateAnimations))
-            displayLink?.add(to: .current, forMode: .common)
+
+            guard let displayLink = displayLink else {
+                print("[Wave] Unable to create display link.")
+                return
+            }
+
+            displayLink.add(to: .current, forMode: .common)
+
+            if #available(iOS 15.0, *) {
+                let maximumFramesPerSecond = Float(UIScreen.main.maximumFramesPerSecond)
+                let highFPSEnabled = maximumFramesPerSecond > 60
+                let minimumFPS: Float = highFPSEnabled ? 80 : 60
+                displayLink.preferredFrameRateRange = .init(minimum: minimumFPS, maximum: maximumFramesPerSecond, preferred: maximumFramesPerSecond)
+            }
         }
     }
 


### PR DESCRIPTION
We needed to set the `preferredFrameRateRange` on Wave's display link, and set the Info.plist key `CADisableMinimumFrameDuration` to `true`.