### PR TITLE
Improve backgroundColor animation retargeting #19

### DIFF
--- a/Sources/Wave/Extensions/UIColor+Extensions.swift
+++ b/Sources/Wave/Extensions/UIColor+Extensions.swift
@@ -8,6 +8,29 @@
 import Foundation
 import UIKit
 
+struct RGBAComponents: Equatable {
+    let r: CGFloat
+    let g: CGFloat
+    let b: CGFloat
+    let a: CGFloat
+
+    init(r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        self.r = r
+        self.g = g
+        self.b = b
+        self.a = a
+    }
+
+    init(color: UIColor) {
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        self.init(r: r, g: g, b: b, a: a)
+    }
+}
+
 extension UIColor {
 
     /**

--- a/Sources/Wave/Extensions/UIColor+Extensions.swift
+++ b/Sources/Wave/Extensions/UIColor+Extensions.swift
@@ -29,6 +29,10 @@ struct RGBAComponents: Equatable {
         color.getRed(&r, green: &g, blue: &b, alpha: &a)
         self.init(r: r, g: g, b: b, a: a)
     }
+
+    var uiColor: UIColor {
+        UIColor(red: r, green: g, blue: b, alpha: a)
+    }
 }
 
 extension UIColor {
@@ -42,8 +46,8 @@ extension UIColor {
      */
     public static func interpolate(from fromColor: UIColor, to toColor: UIColor, with progress: CGFloat) -> UIColor {
         let progress = clipUnit(value: progress)
-        let fromComponents = fromColor.components
-        let toComponents = toColor.components
+        let fromComponents = fromColor.rgbaComponents
+        let toComponents = toColor.rgbaComponents
 
         let r = (1 - progress) * fromComponents.r + progress * toComponents.r
         let g = (1 - progress) * fromComponents.g + progress * toComponents.g
@@ -53,13 +57,7 @@ extension UIColor {
         return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 
-    /// The RGBA components associated with a `UIColor` instance.
-    var components: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-        let components = self.cgColor.components!
-        if components.count == 2 {
-            return (r: components[0], g: components[0], b: components[0], a: components[1])
-        } else {
-            return (r: components[0], g: components[1], b: components[2], a: components[3])
-        }
+    var rgbaComponents: RGBAComponents {
+        RGBAComponents(color: self)
     }
 }

--- a/Sources/Wave/SpringInterpolatable.swift
+++ b/Sources/Wave/SpringInterpolatable.swift
@@ -87,3 +87,31 @@ extension CGRect: SpringInterpolatable, VelocityProviding {
         return (value: newValue, velocity: newVelocity)
     }
 }
+
+extension RGBAComponents: SpringInterpolatable, VelocityProviding {
+
+    typealias ValueType = RGBAComponents
+    typealias VelocityType = RGBAComponents
+
+    static func updateValue(spring: Spring, value: RGBAComponents, target: RGBAComponents, velocity: RGBAComponents, dt: TimeInterval) -> (value: RGBAComponents, velocity: RGBAComponents) {
+        let (newR, newVelocityR) = CGFloat.updateValue(spring: spring, value: value.r, target: target.r, velocity: velocity.r, dt: dt)
+        let (newG, newVelocityG) = CGFloat.updateValue(spring: spring, value: value.g, target: target.g, velocity: velocity.g, dt: dt)
+        let (newB, newVelocityB) = CGFloat.updateValue(spring: spring, value: value.b, target: target.b, velocity: velocity.b, dt: dt)
+        let (newA, newVelocityA) = CGFloat.updateValue(spring: spring, value: value.a, target: target.a, velocity: velocity.a, dt: dt)
+
+        let newValue = RGBAComponents(r: newR, g: newG, b: newB, a: newA)
+        let newVelocity = RGBAComponents(r: newVelocityR, g: newVelocityG, b: newVelocityB, a: newVelocityA)
+
+        return (value: newValue, newVelocity)
+    }
+
+    var scaledIntegral: RGBAComponents {
+        self
+    }
+
+    static var zero: RGBAComponents {
+        RGBAComponents(r: 0, g: 0, b: 0, a: 0)
+    }
+
+
+}

--- a/Sources/Wave/ViewAnimator.swift
+++ b/Sources/Wave/ViewAnimator.swift
@@ -30,8 +30,8 @@ public class ViewAnimator {
         case boundsSize
         case boundsOrigin
 
-        case alpha
         case backgroundColor
+        case alpha
 
         case scale
         case translation
@@ -249,9 +249,13 @@ public class ViewAnimator {
     }
 
     /// The background color of the attached `UIView`.
-    public var backgroundColor: UIColor? {
+    public var backgroundColor: UIColor {
         get {
-            view.backgroundColor
+            if let rgba = runningBackgroundColorAnimator?.value {
+                return UIColor(red: rgba.r, green: rgba.g, blue: rgba.b, alpha: rgba.a)
+            } else {
+                return view.backgroundColor ?? .clear
+            }
         }
         set {
             guard backgroundColor != newValue else {
@@ -265,31 +269,35 @@ public class ViewAnimator {
                 return
             }
 
-            guard let targetValue = newValue else {
-                view.backgroundColor = nil
-                return
-            }
+            // `nil` and `.clear` are the same -- they both are represented by `.white` with an alpha of zero.
+            let initialValue = view.backgroundColor ?? .clear
+
+            // Animating to `clear` or `nil` really just animates the alpha component down to zero. Retain the other color components.
+            let targetValue = (newValue == UIColor.clear) ? backgroundColor.withAlphaComponent(0) : newValue
 
             let animationType = AnimatableProperty.backgroundColor
-            let existingAnimationForType = view.animators[animationType]
 
             // Re-targeting an animation.
-            AnimationController.shared.executeHandler(uuid: existingAnimationForType?.groupUUID, finished: false, retargeted: true)
+            AnimationController.shared.executeHandler(uuid: runningBackgroundColorAnimator?.groupUUID, finished: false, retargeted: true)
 
-            let animation = (existingAnimationForType as? SpringAnimator<CGFloat> ?? SpringAnimator<CGFloat>(spring: settings.spring, value: 0, target: 1))
+            let initialValueComponents = RGBAComponents(color: initialValue)
+            let targetValueComponents = RGBAComponents(color: targetValue)
+
+            let animation = (runningBackgroundColorAnimator ??
+                             SpringAnimator<RGBAComponents>(
+                                spring: settings.spring,
+                                value:  initialValueComponents,
+                                target: targetValueComponents
+                             )
+            )
 
             animation.configure(withSettings: settings)
 
-            let initialColor = view.backgroundColor
-
-            animation.valueChanged = { [weak self] progress in
-                if let initialColor = initialColor {
-                    self?.view.backgroundColor = UIColor.interpolate(from: initialColor, to: targetValue, with: progress)
-                }
+            animation.target = targetValueComponents
+            animation.valueChanged = { [weak self] components in
+                self?.view.backgroundColor = UIColor(red: components.r, green: components.g, blue: components.b, alpha: components.a)
             }
 
-            animation.value = 0
-            animation.target = 1.0
             animation.completion = { [weak self] event in
                 switch event {
                 case .finished(at: _):
@@ -303,7 +311,6 @@ public class ViewAnimator {
             start(animation: animation, type: animationType, delay: settings.delay)
         }
     }
-
 
     /// The alpha of the attached `UIView`.
     public var alpha: CGFloat {
@@ -676,6 +683,10 @@ extension ViewAnimator {
         view.animators[AnimatableProperty.translation] as? SpringAnimator<CGPoint>
     }
 
+    private var runningBackgroundColorAnimator: SpringAnimator<RGBAComponents>? {
+        view.animators[AnimatableProperty.backgroundColor] as? SpringAnimator<RGBAComponents>
+    }
+    
     private var runningAlphaAnimator: SpringAnimator<CGFloat>? {
         view.animators[AnimatableProperty.alpha] as? SpringAnimator<CGFloat>
     }

--- a/Sources/Wave/ViewAnimator.swift
+++ b/Sources/Wave/ViewAnimator.swift
@@ -251,8 +251,8 @@ public class ViewAnimator {
     /// The background color of the attached `UIView`.
     public var backgroundColor: UIColor {
         get {
-            if let rgba = runningBackgroundColorAnimator?.value {
-                return UIColor(red: rgba.r, green: rgba.g, blue: rgba.b, alpha: rgba.a)
+            if let targetComponents = runningBackgroundColorAnimator?.target {
+                return targetComponents.uiColor
             } else {
                 return view.backgroundColor ?? .clear
             }
@@ -295,7 +295,7 @@ public class ViewAnimator {
 
             animation.target = targetValueComponents
             animation.valueChanged = { [weak self] components in
-                self?.view.backgroundColor = UIColor(red: components.r, green: components.g, blue: components.b, alpha: components.a)
+                self?.view.backgroundColor = components.uiColor
             }
 
             animation.completion = { [weak self] event in
@@ -686,7 +686,7 @@ extension ViewAnimator {
     private var runningBackgroundColorAnimator: SpringAnimator<RGBAComponents>? {
         view.animators[AnimatableProperty.backgroundColor] as? SpringAnimator<RGBAComponents>
     }
-    
+
     private var runningAlphaAnimator: SpringAnimator<CGFloat>? {
         view.animators[AnimatableProperty.alpha] as? SpringAnimator<CGFloat>
     }

--- a/Tests/WaveTests/UIViewAnimatablePropertyTests.swift
+++ b/Tests/WaveTests/UIViewAnimatablePropertyTests.swift
@@ -169,6 +169,48 @@ final class UIViewAnimatablePropertyTests: XCTestCase {
         }
     }
 
+    func testBackgroundColor() {
+        let view = UIView()
+
+        let initialValue = UIColor.red
+        let targetValue = UIColor.blue
+
+        view.backgroundColor = initialValue
+
+        Wave.animate(withSpring: .defaultAnimated) {
+            view.animator.backgroundColor = targetValue
+        }
+
+        XCTAssertEqual(view.backgroundColor?.rgbaComponents, initialValue.rgbaComponents)
+        XCTAssertEqual(view.animator.backgroundColor.rgbaComponents, targetValue.rgbaComponents)
+
+        wait(for: .defaultAnimated) {
+            XCTAssertEqual(view.backgroundColor?.rgbaComponents, targetValue.rgbaComponents)
+            XCTAssertEqual(view.animator.backgroundColor.rgbaComponents, targetValue.rgbaComponents)
+        }
+    }
+
+    func testBackgroundColorClear() {
+        let view = UIView()
+
+        let initialValue = UIColor.clear
+        let targetValue = UIColor.blue.withAlphaComponent(0.5)
+
+        view.backgroundColor = initialValue
+
+        Wave.animate(withSpring: .defaultAnimated) {
+            view.animator.backgroundColor = targetValue
+        }
+
+        XCTAssertEqual(view.backgroundColor?.rgbaComponents, initialValue.rgbaComponents)
+        XCTAssertEqual(view.animator.backgroundColor.rgbaComponents, targetValue.rgbaComponents)
+
+        wait(for: .defaultAnimated) {
+            XCTAssertEqual(view.backgroundColor?.rgbaComponents, targetValue.rgbaComponents)
+            XCTAssertEqual(view.animator.backgroundColor.rgbaComponents, targetValue.rgbaComponents)
+        }
+    }
+
     func testAlpha() {
         let view = UIView()
 


### PR DESCRIPTION
This PR re-architects how Wave does `backgroundColor` interpolation. Now, we decompose colors into their components, and animate each component on its own spring.

This allows colors to be correctly re-targeted in-flight, fixing any jittering/flashing.