### PR TITLE
Non-animated updates shouldn't wait until the next turn of the run loop #26

### DIFF
--- a/Sources/Wave/Internal/AnimationController.swift
+++ b/Sources/Wave/Internal/AnimationController.swift
@@ -74,6 +74,8 @@ internal class AnimationController {
         }
 
         animations[animation.id] = animation
+
+        animation.updateAnimation(dt: .zero)
     }
 
     internal func executeHandler(uuid: UUID?, finished: Bool, retargeted: Bool) {

--- a/Sources/Wave/SpringAnimator.swift
+++ b/Sources/Wave/SpringAnimator.swift
@@ -216,7 +216,9 @@ public class SpringAnimator<T: SpringInterpolatable>: AnimatorProviding {
         let newValue: T.ValueType
         let newVelocity: T.VelocityType
 
-        if spring.response > .zero && mode != .nonAnimated {
+        let isAnimated = spring.response > .zero && mode != .nonAnimated
+
+        if isAnimated {
             (newValue, newVelocity) = T.updateValue(spring: spring, value: value, target: target, velocity: velocity, dt: dt)
         } else {
             newValue = target
@@ -226,7 +228,7 @@ public class SpringAnimator<T: SpringInterpolatable>: AnimatorProviding {
         self.value = newValue
         self.velocity = newVelocity
 
-        let animationFinished = runningTime >= (self.settlingTime)
+        let animationFinished = (runningTime >= settlingTime) || !isAnimated
 
         if animationFinished {
             self.value = target

--- a/Tests/WaveTests/AnimatableUIViewPropertyTests.swift
+++ b/Tests/WaveTests/AnimatableUIViewPropertyTests.swift
@@ -228,11 +228,41 @@ final class UIViewAnimatablePropertyTests: XCTestCase {
 
         XCTAssertEqual(view.alpha, initialValue)
         XCTAssertEqual(view.animator.alpha, targetValue)
+        XCTAssertEqual(Double(view.layer.animator.opacity), targetValue)
 
         wait(for: .defaultAnimated) {
             XCTAssertEqual(view.alpha, targetValue)
             XCTAssertEqual(view.animator.alpha, targetValue)
         }
+    }
+
+    func testNonAnimatedAlpha() {
+        let view = UIView()
+
+        let initialValue = 1.0
+        let targetValue = 0.5
+
+        view.alpha = initialValue
+
+        Wave.animate(withSpring: .defaultNonAnimated) {
+            view.animator.alpha = targetValue
+        }
+
+        XCTAssertEqual(view.alpha, targetValue)
+        XCTAssertEqual(view.animator.alpha, targetValue)
+
+        XCTAssertEqual(Double(view.layer.opacity), targetValue)
+        XCTAssertEqual(view.layer.animator.opacity, targetValue)
+
+        Wave.animate(withSpring: .defaultAnimated, mode: .nonAnimated) {
+            view.animator.alpha = initialValue
+        }
+
+        XCTAssertEqual(view.alpha, initialValue)
+        XCTAssertEqual(view.animator.alpha, initialValue)
+
+        XCTAssertEqual(Double(view.layer.opacity), initialValue)
+        XCTAssertEqual(view.layer.animator.opacity, initialValue)
     }
 
     func testPropertyAnimation() {

--- a/Tests/WaveTests/AnimatableUIViewPropertyTests.swift
+++ b/Tests/WaveTests/AnimatableUIViewPropertyTests.swift
@@ -97,6 +97,19 @@ final class UIViewAnimatablePropertyTests: XCTestCase {
         }
     }
 
+    func testNonAnimatedBoundsSize() {
+        let v = UIView()
+
+        let initialBoundsSize = CGSize(width: 50, height: 50)
+        let targetFrameSize = CGSize(width: 25, height: 25)
+
+        v.bounds.size = initialBoundsSize
+        v.animator.scale = CGPoint(x: 0.5, y: 0.5)
+
+        XCTAssertEqual(v.bounds.size, initialBoundsSize)
+        XCTAssertEqual(v.frame.size, targetFrameSize)
+    }
+
     func testCenter() {
         let view = UIView()
 


### PR DESCRIPTION
Copied from #26:

```swift
let v = UIView()
v.bounds.size = CGSize(width: 50, height: 50)
v.animator.scale = CGPoint(x: 0.5, y: 0.5)

print(v.frame.size)
```

This will print `(50, 50)` instead of `(25, 25)` until the next turn of the run loop. We shouldn't require the display link to fire to update things non-animatedly.