### PR TITLE
Fix display link frame rate range

### DIFF
--- a/Sources/Wave/Internal/DisplayLinkProviding.swift
+++ b/Sources/Wave/Internal/DisplayLinkProviding.swift
@@ -35,7 +35,7 @@ class CADisplayLinkProvider: DisplayLinkProviding {
         if #available(iOS 15.0, *) {
             let maximumFramesPerSecond = Float(UIScreen.main.maximumFramesPerSecond)
             let highFPSEnabled = maximumFramesPerSecond > 60
-            let minimumFPS: Float = highFPSEnabled ? 80 : 60
+            let minimumFPS: Float = min(highFPSEnabled ? 80 : 60, maximumFramesPerSecond)
             displayLinkProvider?.preferredFrameRateRange = .init(minimum: minimumFPS, maximum: maximumFramesPerSecond, preferred: maximumFramesPerSecond)
         }
     }


### PR DESCRIPTION
According to the documentation, `maximumFramesPerSecond`, for devices with ProMotion displays, the value of this property can reach 120.

 I found that in some cases, the return value of this property will be 61 instead of 60, so the `highFPSEnabled` judgment will be invalid. 

So I added a minimum value determination to make sure that the minimum value is less than the maximum value.